### PR TITLE
Fix frame id and compiling issues C++ 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(livox_dedistortion_pkg)
 
 SET(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "-std=c++14")
 
 #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/src/data_process.cpp
+++ b/src/data_process.cpp
@@ -140,7 +140,7 @@ void ImuProcess::Process(const MeasureGroup &meas)
     sensor_msgs::PointCloud2 pcl_out_msg;
     pcl::toROSMsg(*laserCloudtmp, pcl_out_msg);
     pcl_out_msg.header = pcl_in_msg->header;
-    pcl_out_msg.header.frame_id = "/livox_frame";
+    pcl_out_msg.header.frame_id = "livox_frame";
     pub_UndistortPcl.publish(pcl_out_msg);
     laserCloudtmp->clear();
   }
@@ -151,7 +151,7 @@ void ImuProcess::Process(const MeasureGroup &meas)
     sensor_msgs::PointCloud2 pcl_out_msg;
     pcl::toROSMsg(*cur_pcl_un_, pcl_out_msg);
     pcl_out_msg.header = pcl_in_msg->header;
-    pcl_out_msg.header.frame_id = "/livox_frame";
+    pcl_out_msg.header.frame_id = "livox_frame";
     pub_UndistortPcl.publish(pcl_out_msg);
   }
 
@@ -162,7 +162,7 @@ void ImuProcess::Process(const MeasureGroup &meas)
     std::cout << "point size: " << cur_pcl_in_->points.size() << "\n";
     pcl::toROSMsg(*cur_pcl_in_, pcl_out_msg);
     pcl_out_msg.header = pcl_in_msg->header;
-    pcl_out_msg.header.frame_id = "/livox_frame";
+    pcl_out_msg.header.frame_id = "livox_frame";
     pub_UndistortPcl.publish(pcl_out_msg);
   }
 
@@ -172,3 +172,4 @@ void ImuProcess::Process(const MeasureGroup &meas)
   cur_pcl_in_.reset(new PointCloudXYZI());
   cur_pcl_un_.reset(new PointCloudXYZI());
 }
+

--- a/src/livox_repub.cpp
+++ b/src/livox_repub.cpp
@@ -38,7 +38,7 @@ void LivoxMsgCbk1(const livox_ros_driver::CustomMsgConstPtr& livox_msg_in) {
   sensor_msgs::PointCloud2 pcl_ros_msg;
   pcl::toROSMsg(pcl_in, pcl_ros_msg);
   pcl_ros_msg.header.stamp.fromNSec(timebase_ns);
-  pcl_ros_msg.header.frame_id = "/livox";
+  pcl_ros_msg.header.frame_id = "livox";
   pub_pcl_out1.publish(pcl_ros_msg);
   livox_data.clear();
 }
@@ -55,3 +55,4 @@ int main(int argc, char** argv) {
 
   ros::spin();
 }
+


### PR DESCRIPTION
- The frame ids included the backslash symbol which was throwing an error in rviz
- As PCL requires C++ version 14 I changed the CMakeLists file to include the updated version